### PR TITLE
Small tweak to HTML for form Translate

### DIFF
--- a/formtranslate/templates/formtranslate/home.html
+++ b/formtranslate/templates/formtranslate/home.html
@@ -8,17 +8,19 @@
     <script type="text/javascript">
     $(function() {
         // styling
-        $('#notify').addClass("hidden");
         
         // api
         var do_api = function(url, textonly) {
+            $('#notify').addClass("notice");
+            $('#notify').text("Working...");
             var xform = $("#xform").val();
             jQuery.post(url, {xform: xform},
                         function(data){
                             json_res = data;
                             notice = $('#notify');
-                            notice.removeClass("hidden success error");
+                            notice.removeClass("hidden success error notice");
                             if (json_res.success) {
+
                                 notice.addClass("success");
                                 if (textonly) {
                                     notice.text("Success!   " + json_res.outstring);
@@ -26,6 +28,7 @@
                                     notice.html("Success!<br><br>" + json_res.outstring.replace(/\n/g , "<br>"));
                                 }
                             } else {
+                                
                                 notice.addClass("error");
                                 notice.html("Error!<br><br>" + json_res.errstring.replace(/\n/g , "<br>"));
                             }


### PR DESCRIPTION
It was bugging me that you there's no visual indicator when you hit 'validate' (or the other buttons) to show that formtranslate is doing something in the background. So:

Tweaked home.html to show indicator to user while performing the HTTP POST step

Cheers,
Anton
