### PR TITLE
remove incorrect assert

### DIFF
--- a/formtranslate/api.py
+++ b/formtranslate/api.py
@@ -69,7 +69,7 @@ def form_translate(input_data, operation, version='1.0'):
     except sh.ErrorReturnCode_1 as e:
         result = e
         success = False
-    assert success == ("exception" not in result.stderr.lower())
+
     return {
         "success": success,
         "errstring": result.stderr,


### PR DESCRIPTION
this was me being curious whether the old code's method for
distinguishing an error from success was correct.
It wasn't, apparently, and not surprisingly.
