### PR TITLE
use new urls module

### DIFF
--- a/formtranslate/urls.py
+++ b/formtranslate/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('formtranslate.views',
     url(r'^$', 'home', name='formtranslate_home'),


### PR DESCRIPTION
django.conf.urls.defaults is deprecated and removed in Django 1.6