### PR TITLE
Change default version

### DIFF
--- a/formtranslate/views.py
+++ b/formtranslate/views.py
@@ -7,7 +7,7 @@ import json
 
 
 def home(request):
-    version = request.GET.get('version', '1.0')
+    version = request.GET.get('version', '2.0')
     return render_to_response("formtranslate/home.html",
                               {'version': version}, RequestContext(request))
     


### PR DESCRIPTION
Make formtranslate slightly easier to use by populating the version with 2.0 instead of 1.0 by default (all forms these days are 2.0).
cc @kaapstorm 